### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Starting array is printed only if -a is not used.
 Command line arguments:  
 	-l length, how long of a list is used. default 10.  
 	-m max, biggest number allowed in the list. default 255.  
-	-a values..., values used to specify an array to sort. overrides -c and -v.
+	-a values..., values used to specify an array to sort. overrides -l
 
 Example commands:
 >python PrimeSort.py -a 7 3 2 9 5  

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ Primesort is a successor to bogosort. It has been improved by using primes to sh
 
 Starting array is printed only if -a is not used.  
 
-Command line arguments:
+Command line arguments:  
 	-l length, how long of a list is used. default 10.  
 	-m max, biggest number allowed in the list. default 255.  
 	-a values..., values used to specify an array to sort. overrides -c and -v.
 
 Example commands:
-	python PrimeSort.py -a 7 3 2 9 5
-	python PrimeSort.py -l 7 -m 100
+>python PrimeSort.py -a 7 3 2 9 5  
+>python PrimeSort.py -l 7 -m 100


### PR DESCRIPTION
Separates the example commands and removes reference to arguments which don't exist in this project.